### PR TITLE
Relax color spec validation

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -92,22 +92,13 @@ class syntax_plugin_color extends DokuWiki_Syntax_Plugin {
  
     // validate color value $c
     // this is cut price validation - only to ensure there is nothing harmful
-    // recognize rgb, rgba, hsl, hsla but don't try to valiedate their arguments,
     // just ensure that no illegal characters are included therein
-    // and that the number of characters is reasonable
     // leave it to the browsers to ignore a faulty colour specification
     function _isValid($c) {
-        $c = trim($c);
+        if (strpos($c, ';') === false)
+            return trim($c);
  
-        $pattern = "/^\s*(
-            ([a-zA-Z]+)|                         #colorname - not verified
-            (\#([0-9a-fA-F]{3,8}))|              #colorvalue including possible alpha
-            ((rgba?|hsla?)\([0-9%., ]{5,40}\))   #rgb[a], hsl[a]
-            )\s*$/x";
- 
-        if (preg_match($pattern, $c)) return trim($c);
- 
-        return "";
+        return '';
     }
 }
 ?>

--- a/syntax.php
+++ b/syntax.php
@@ -28,10 +28,11 @@ class syntax_plugin_color extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
           case DOKU_LEXER_ENTER :
-                list($color, $background) = preg_split("/\//u", substr($match, 6, -1), 2);
-                if ($color = $this->_isValid($color)) $color = "color:$color;";
-                if ($background = $this->_isValid($background)) $background = "background-color:$background;";
-                return array($state, array($color, $background));
+              $m = explode('/', substr($match, 6, -1));
+              $color = $this->_specToCSS('color', $m[0]);
+              $background = $this->_specToCSS('background-color',
+                                              isset($m[1]) ? $m[1] : null);
+              return [$state, [$color, $background]];
  
           case DOKU_LEXER_UNMATCHED :  return array($state, $match);
           case DOKU_LEXER_EXIT :       return array($state, '');
@@ -89,16 +90,20 @@ class syntax_plugin_color extends DokuWiki_Syntax_Plugin {
         }
         return false;
     }
- 
+  
+    // Build a CSS attribute:value pair.
+    function _specToCSS($attrib, $c) {
+        return ((!empty($c) &&
+                 $this->_isValid($c)) ? $attrib.':'.trim($c).';'
+                                      : null);
+    }
+
     // validate color value $c
     // this is cut price validation - only to ensure there is nothing harmful
     // just ensure that no illegal characters are included therein
     // leave it to the browsers to ignore a faulty colour specification
     function _isValid($c) {
-        if (strpos($c, ';') === false)
-            return trim($c);
- 
-        return '';
+        return (false === strpbrk($c, '"\'<>&;'));
     }
 }
 ?>


### PR DESCRIPTION
Fixes #6 and makes the validation future proof in case more color specifications are allowed in the CSS standard.

Makes sure there is no ; in the color spec as that could lead to additional css being brought in via this plugin which might pose a security risk.